### PR TITLE
[#30] Do not include test files into build

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "integration-test:ci": "dotenv -e .env.test.ci -- vitest -c ./vitest-integration-test.config.ts --no-threads",
     "db-studio": "prisma studio",
     "typecheck": "tsc --noEmit",
-    "build": "tsup ./src/"
+    "build": "tsup"
   },
   "keywords": [
     "NodeJS",

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig(options => ({
+  entry: ['src', '!src/**/*.spec.*', '!src/**/*.test.*'],
+  splitting: false,
+  sourcemap: false,
+  clean: true,
+  minify: !options.watch
+}))


### PR DESCRIPTION
fix #30 

### Description

Create a config file for tsup package and exclude tests files with pattern `.spec.ts` and `.test.ts` in production build. Remove path defined in `package.json` and use the path from `tsup.config.ts`.

### Checklist

- [x] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary
